### PR TITLE
Await code

### DIFF
--- a/frontend/src/composables/useTasks.js
+++ b/frontend/src/composables/useTasks.js
@@ -308,7 +308,7 @@ export function useTasks(settings, glossary, i18n) {
             task.isFinished = false;
             task.logs = '';
             task.downloads = null;
-            toggleTaskState(task, errors);
+            await toggleTaskState(task, errors);
             return;
         }
 


### PR DESCRIPTION
Not sure how often code hits the edge case, but The promise result gets used as if it were already resolved. this patch adds the missing await so the async path is actually sequenced. Close this if it’s not worth the noise.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.