### PR TITLE
feat: add record translation support to SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,14 @@ dist/
 wheels/
 *.egg-info
 tests/
+!tests/
+tests/*
+!tests/test_translator/
+tests/test_translator/*
+!tests/test_translator/test_json_translator.py
+!tests/test_workflow/
+tests/test_workflow/*
+!tests/test_workflow/test_record_helper.py
 tests/resource/
 tests/test_data/
 htmlcov/

--- a/README.md
+++ b/README.md
@@ -455,6 +455,65 @@ Key config options:
 - **json_paths**: JSONPath expressions for JSON translation (e.g., `["$.*", "$.name"]`)
 - **separator**: Text separator for `"append"` / `"prepend"` modes
 
+When using the JSON workflow, prefer explicit field paths such as `["$.items[*].text"]` when only specific values
+should be translated. This keeps non-matching fields, such as IDs, flags, and metadata, unchanged in the output JSON.
+
+### Record Translation (Batch Records with IDs)
+
+For scenarios where you have a list of records with unique IDs and need to translate only the text field
+while preserving all other fields (CMS exports, database dumps, CAD annotations, subtitle files, etc.),
+use the `translate_records` convenience method:
+
+```python
+from docutranslate.sdk import Client
+
+client = Client(
+    api_key="YOUR_API_KEY",
+    base_url="https://api.openai.com/v1/",
+    model_id="gpt-4o",
+    to_lang="Chinese",
+)
+
+records = [
+    {"record_id": "r1", "source_text": "总说明", "category": "doc"},
+    {"record_id": "r2", "source_text": "平面图", "category": "drawing"},
+    {"record_id": "r3", "source_text": "施工进度", "category": "schedule"},
+]
+
+translated = client.translate_records(records)
+
+# translated[0] = {"record_id": "r1", "source_text": "General Description", "category": "doc"}
+# All non-text fields (category, etc.) are preserved.
+```
+
+Custom field names (for different JSON structures):
+
+```python
+translated = client.translate_records(
+    records,
+    id_field="key",           # custom ID field name
+    text_field="content",     # custom text field name
+    records_key="items",      # custom records array key
+)
+```
+
+**Web API** — `POST /service/translate/records`:
+
+```json
+{
+  "records": [
+    {"record_id": "r1", "source_text": "总说明"},
+    {"record_id": "r2", "source_text": "平面图"}
+  ],
+  "id_field": "record_id",
+  "text_field": "source_text",
+  "to_lang": "English",
+  "api_key": "sk-xxx",
+  "base_url": "https://api.openai.com/v1",
+  "model_id": "gpt-4o"
+}
+```
+
 ## Prerequisites and Detailed Configuration
 
 ### 1. Get Large Model API Key

--- a/docutranslate/sdk.py
+++ b/docutranslate/sdk.py
@@ -4,7 +4,9 @@
 
 import asyncio
 import base64
+import json
 import os
+import tempfile
 from pathlib import Path
 from typing import Optional, Literal, Dict, Any, List, Union
 
@@ -18,6 +20,7 @@ from docutranslate.core.factory import create_workflow_from_payload
 from docutranslate.translator import default_params
 from docutranslate.global_values.conditional_import import DOCLING_EXIST
 from docutranslate.config import TO_LANG
+from docutranslate.workflow.record_helper import RecordFieldMapping, RecordTranslationHelper
 
 # --- 映射配置 ---
 # 格式说明: {workflow_type: {save_type: (method_name, default_suffix)}}
@@ -385,6 +388,90 @@ class Client:
             await workflow.translate_async()
 
         return TranslationResult(workflow, final_params["workflow_type"], path_obj.name)
+
+    # ------------------------------------------------------------------
+    # Record-based translation (batch records with IDs)
+    # ------------------------------------------------------------------
+
+    def translate_records(
+            self,
+            records: List[Dict[str, Any]],
+            *,
+            id_field: str = "record_id",
+            text_field: str = "source_text",
+            records_key: str = "records",
+            output_dir: str = "./output",
+            **kwargs,
+    ) -> List[Dict[str, Any]]:
+        """Translate a list of records that each carry an ID and a text field.
+
+        This is a convenience wrapper around :meth:`translate` for the common
+        "batch text translation with ID tracking" pattern found in CMS exports,
+        database dumps, CAD annotation lists, subtitle files, etc.
+
+        All non-text fields are preserved; only *text_field* is translated.
+
+        :param records: List of record dicts, e.g.
+            ``[{"record_id": "r1", "source_text": "你好"}]``.
+        :param id_field: Name of the unique-ID field inside each record.
+        :param text_field: Name of the field whose value should be translated.
+        :param records_key: Top-level key that holds the records array in the
+            JSON envelope (default ``"records"``).
+        :param output_dir: Directory for intermediate / output files.
+        :param kwargs: Extra keyword arguments forwarded to :meth:`translate`
+            (e.g. ``concurrent``, ``temperature``, ``custom_prompt``).
+        :returns: A new list of record dicts with *text_field* replaced by the
+            translated text, in the same order as *records*.
+        """
+        return asyncio.run(
+            self.translate_records_async(
+                records,
+                id_field=id_field,
+                text_field=text_field,
+                records_key=records_key,
+                output_dir=output_dir,
+                **kwargs,
+            )
+        )
+
+    async def translate_records_async(
+            self,
+            records: List[Dict[str, Any]],
+            *,
+            id_field: str = "record_id",
+            text_field: str = "source_text",
+            records_key: str = "records",
+            output_dir: str = "./output",
+            **kwargs,
+    ) -> List[Dict[str, Any]]:
+        """Async version of :meth:`translate_records`."""
+        helper = RecordTranslationHelper(
+            RecordFieldMapping(id_field=id_field, text_field=text_field, records_key=records_key)
+        )
+
+        # 1. Build payload and write to a temp file
+        payload = helper.build_payload(records)
+        tmp_dir = Path(output_dir)
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        tmp_input = tmp_dir / "_records_input.json"
+        tmp_input.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        try:
+            # 2. Translate using the existing Client.translate pipeline
+            result = await self.translate_async(
+                str(tmp_input),
+                json_paths=helper.build_json_paths(),
+                **kwargs,
+            )
+
+            # 3. Save translated file and read back
+            saved_path = result.save(output_dir=output_dir, fmt="json")
+            translated_payload = helper.read_translated_payload(saved_path)
+
+            # 4. Map back onto original record order
+            return helper.extract_translated_records(records, translated_payload)
+        finally:
+            tmp_input.unlink(missing_ok=True)
 
     def _detect_workflow(self, path: Path) -> str:
         ext = path.suffix.lower().lstrip(".")

--- a/docutranslate/sdk.py
+++ b/docutranslate/sdk.py
@@ -472,6 +472,8 @@ class Client:
             return helper.extract_translated_records(records, translated_payload)
         finally:
             tmp_input.unlink(missing_ok=True)
+            if 'saved_path' in locals() and Path(saved_path).exists():
+                Path(saved_path).unlink(missing_ok=True)
 
     def _detect_workflow(self, path: Path) -> str:
         ext = path.suffix.lower().lstrip(".")

--- a/docutranslate/translator/ai_translator/json_translator.py
+++ b/docutranslate/translator/ai_translator/json_translator.py
@@ -106,7 +106,10 @@ class JsonTranslator(AiTranslator):
         # 1. 查找所有顶层匹配项
         all_matches = []
         for path_str in self.json_paths:
-            jsonpath_expr = parse(path_str)
+            try:
+                jsonpath_expr = parse(path_str)
+            except Exception as exc:
+                raise ValueError(f"Invalid json_paths expression: {path_str}") from exc
             all_matches.extend(jsonpath_expr.find(content))
 
         # 2. 遍历匹配项并启动递归收集

--- a/docutranslate/workflow/record_helper.py
+++ b/docutranslate/workflow/record_helper.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2025 QinHan
+# SPDX-License-Identifier: MPL-2.0
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class RecordFieldMapping:
+    """Defines the field mapping for a record-based JSON structure.
+
+    Default layout matches ``{"records": [{"record_id": "...", "source_text": "..."}]}``
+    but every field name is configurable so that *any* structured data with
+    an ID field and a text field can be translated without a custom adapter.
+    """
+    id_field: str = "record_id"
+    text_field: str = "source_text"
+    records_key: str = "records"
+
+
+class RecordTranslationHelper:
+    """Utility that bridges the "records with IDs" pattern and the existing
+    ``JsonWorkflow`` / ``Client.translate`` pipeline.
+
+    Usage::
+
+        helper = RecordTranslationHelper()
+        payload  = helper.build_payload(records)
+        paths    = helper.build_json_paths()
+        # ... feed payload + paths to JsonWorkflow / Client.translate ...
+        results  = helper.extract_translated_records(records, translated_payload)
+    """
+
+    def __init__(self, field_mapping: RecordFieldMapping | None = None):
+        self.field_mapping = field_mapping or RecordFieldMapping()
+
+    # ------------------------------------------------------------------
+    # Payload construction
+    # ------------------------------------------------------------------
+
+    def build_json_paths(self) -> list[str]:
+        """Return the ``json_paths`` expression that targets *only* the text
+        field inside each record."""
+        fm = self.field_mapping
+        return [f"$.{fm.records_key}[*].{fm.text_field}"]
+
+    def build_payload(self, records: Sequence[Dict[str, Any]]) -> dict[str, Any]:
+        """Wrap *records* inside the expected JSON envelope."""
+        return {self.field_mapping.records_key: list(records)}
+
+    # ------------------------------------------------------------------
+    # Result extraction
+    # ------------------------------------------------------------------
+
+    def extract_translated_records(
+        self,
+        original_records: Sequence[Dict[str, Any]],
+        translated_payload: Dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Map the translated payload back onto the original record order.
+
+        * All non-text fields are preserved from the original record.
+        * The text field is replaced with the translated value.
+        * If a record ID is missing from the translated payload the original
+          record is returned unchanged (graceful degradation).
+        """
+        fm = self.field_mapping
+        translated_items: list[dict[str, Any]] = translated_payload.get(fm.records_key, [])
+
+        # Index translated items by ID
+        translated_by_id: dict[str, dict[str, Any]] = {}
+        for item in translated_items:
+            if not isinstance(item, dict):
+                continue
+            rid = str(item.get(fm.id_field, ""))
+            if rid:
+                translated_by_id[rid] = item
+
+        results: list[dict[str, Any]] = []
+        for original in original_records:
+            rid = str(original.get(fm.id_field, ""))
+            translated = translated_by_id.get(rid)
+            if translated and isinstance(translated.get(fm.text_field), str):
+                merged = dict(original)  # preserve all original fields
+                merged[fm.text_field] = translated[fm.text_field]
+                results.append(merged)
+            else:
+                results.append(dict(original))
+        return results
+
+    # ------------------------------------------------------------------
+    # Convenience: file I/O for SDK / API integration
+    # ------------------------------------------------------------------
+
+    def write_payload_to_file(
+        self,
+        records: Sequence[Dict[str, Any]],
+        output_path: Path | str,
+    ) -> Path:
+        """Serialize *records* as a JSON file suitable for ``JsonWorkflow``."""
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = self.build_payload(records)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        return path
+
+    def read_translated_payload(self, file_path: Path | str) -> dict[str, Any]:
+        """Read a translated JSON file back into a dict."""
+        return json.loads(Path(file_path).read_text(encoding="utf-8"))

--- a/docutranslate/workflow/record_helper.py
+++ b/docutranslate/workflow/record_helper.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Sequence
 
 
 @dataclass(frozen=True)
@@ -47,7 +47,7 @@ class RecordTranslationHelper:
         fm = self.field_mapping
         return [f"$.{fm.records_key}[*].{fm.text_field}"]
 
-    def build_payload(self, records: Sequence[Dict[str, Any]]) -> dict[str, Any]:
+    def build_payload(self, records: Sequence[dict[str, Any]]) -> dict[str, Any]:
         """Wrap *records* inside the expected JSON envelope."""
         return {self.field_mapping.records_key: list(records)}
 
@@ -57,8 +57,8 @@ class RecordTranslationHelper:
 
     def extract_translated_records(
         self,
-        original_records: Sequence[Dict[str, Any]],
-        translated_payload: Dict[str, Any],
+        original_records: Sequence[dict[str, Any]],
+        translated_payload: dict[str, Any],
     ) -> list[dict[str, Any]]:
         """Map the translated payload back onto the original record order.
 
@@ -97,7 +97,7 @@ class RecordTranslationHelper:
 
     def write_payload_to_file(
         self,
-        records: Sequence[Dict[str, Any]],
+        records: Sequence[dict[str, Any]],
         output_path: Path | str,
     ) -> Path:
         """Serialize *records* as a JSON file suitable for ``JsonWorkflow``."""

--- a/tests/test_translator/test_json_translator.py
+++ b/tests/test_translator/test_json_translator.py
@@ -1,0 +1,57 @@
+import json
+
+import pytest
+
+from docutranslate.ir.document import Document
+from docutranslate.translator.ai_translator.json_translator import JsonTranslator, JsonTranslatorConfig
+
+
+class _FakeTranslateAgent:
+    def send_segments(self, segments, chunk_size):
+        return [f"EN::{segment}" for segment in segments]
+
+
+def _build_translator(*, json_paths: list[str]) -> JsonTranslator:
+    config = JsonTranslatorConfig(
+        base_url="https://example.com/v1",
+        api_key="test-api-key",
+        model_id="test-model",
+        to_lang="English",
+        json_paths=json_paths,
+        skip_translate=True,
+    )
+    return JsonTranslator(config)
+
+
+def test_translate_only_updates_explicit_json_paths():
+    document = Document.from_bytes(
+        json.dumps(
+            {
+                "items": [
+                    {"id": "a-1", "text": "总说明", "status": "draft"},
+                    {"id": "a-2", "text": "平面图", "status": "approved"},
+                ],
+                "owner": "Alice",
+            },
+            ensure_ascii=False,
+        ).encode("utf-8"),
+        suffix=".json",
+        stem="sample",
+    )
+    translator = _build_translator(json_paths=["$.items[*].text"])
+    translator.translate_agent = _FakeTranslateAgent()
+
+    translator.translate(document)
+    translated = json.loads(document.content.decode("utf-8"))
+
+    assert [item["text"] for item in translated["items"]] == ["EN::总说明", "EN::平面图"]
+    assert [item["id"] for item in translated["items"]] == ["a-1", "a-2"]
+    assert [item["status"] for item in translated["items"]] == ["draft", "approved"]
+    assert translated["owner"] == "Alice"
+
+
+def test_invalid_json_path_raises_clear_error():
+    translator = _build_translator(json_paths=["$.items["])
+
+    with pytest.raises(ValueError, match=r"Invalid json_paths expression: \$\.items\["):
+        translator._collect_strings_for_translation({"items": [{"text": "hello"}]})

--- a/tests/test_workflow/test_record_helper.py
+++ b/tests/test_workflow/test_record_helper.py
@@ -1,0 +1,177 @@
+import json
+import pytest
+from pathlib import Path
+
+from docutranslate.workflow.record_helper import RecordFieldMapping, RecordTranslationHelper
+
+
+# ======================================================================
+# RecordFieldMapping defaults
+# ======================================================================
+
+def test_default_field_mapping():
+    fm = RecordFieldMapping()
+    assert fm.id_field == "record_id"
+    assert fm.text_field == "source_text"
+    assert fm.records_key == "records"
+
+
+def test_custom_field_mapping():
+    fm = RecordFieldMapping(id_field="key", text_field="content", records_key="items")
+    assert fm.id_field == "key"
+    assert fm.text_field == "content"
+    assert fm.records_key == "items"
+
+
+# ======================================================================
+# build_json_paths
+# ======================================================================
+
+def test_build_json_paths_default():
+    helper = RecordTranslationHelper()
+    assert helper.build_json_paths() == ["$.records[*].source_text"]
+
+
+def test_build_json_paths_custom():
+    helper = RecordTranslationHelper(
+        RecordFieldMapping(id_field="pk", text_field="text", records_key="items")
+    )
+    assert helper.build_json_paths() == ["$.items[*].text"]
+
+
+# ======================================================================
+# build_payload
+# ======================================================================
+
+def test_build_payload():
+    helper = RecordTranslationHelper()
+    records = [
+        {"record_id": "r1", "source_text": "你好"},
+        {"record_id": "r2", "source_text": "世界"},
+    ]
+    payload = helper.build_payload(records)
+    assert payload == {
+        "records": [
+            {"record_id": "r1", "source_text": "你好"},
+            {"record_id": "r2", "source_text": "世界"},
+        ]
+    }
+
+
+def test_build_payload_custom_key():
+    helper = RecordTranslationHelper(
+        RecordFieldMapping(records_key="items")
+    )
+    records = [{"record_id": "r1", "source_text": "你好"}]
+    payload = helper.build_payload(records)
+    assert "items" in payload
+    assert len(payload["items"]) == 1
+
+
+# ======================================================================
+# extract_translated_records
+# ======================================================================
+
+def test_extract_translated_records_basic():
+    helper = RecordTranslationHelper()
+    original = [
+        {"record_id": "r1", "source_text": "你好", "category": "doc"},
+        {"record_id": "r2", "source_text": "世界", "category": "drawing"},
+    ]
+    translated_payload = {
+        "records": [
+            {"record_id": "r1", "source_text": "Hello"},
+            {"record_id": "r2", "source_text": "World"},
+        ]
+    }
+    result = helper.extract_translated_records(original, translated_payload)
+
+    assert len(result) == 2
+    # Text field updated
+    assert result[0]["source_text"] == "Hello"
+    assert result[1]["source_text"] == "World"
+    # Non-text fields preserved
+    assert result[0]["category"] == "doc"
+    assert result[1]["category"] == "drawing"
+    # ID field preserved
+    assert result[0]["record_id"] == "r1"
+    assert result[1]["record_id"] == "r2"
+
+
+def test_extract_translated_records_missing_id():
+    """If a record ID is missing from translated payload, original is returned."""
+    helper = RecordTranslationHelper()
+    original = [
+        {"record_id": "r1", "source_text": "你好"},
+        {"record_id": "r2", "source_text": "世界"},
+    ]
+    translated_payload = {
+        "records": [
+            {"record_id": "r1", "source_text": "Hello"},
+            # r2 is missing
+        ]
+    }
+    result = helper.extract_translated_records(original, translated_payload)
+
+    assert result[0]["source_text"] == "Hello"
+    assert result[1]["source_text"] == "世界"  # unchanged
+
+
+def test_extract_translated_records_maintains_order():
+    """Results must be in the same order as original records."""
+    helper = RecordTranslationHelper()
+    original = [
+        {"record_id": "a", "source_text": "甲"},
+        {"record_id": "b", "source_text": "乙"},
+        {"record_id": "c", "source_text": "丙"},
+    ]
+    translated_payload = {
+        "records": [
+            {"record_id": "c", "source_text": "C"},
+            {"record_id": "a", "source_text": "A"},
+            {"record_id": "b", "source_text": "B"},
+        ]
+    }
+    result = helper.extract_translated_records(original, translated_payload)
+
+    assert [r["record_id"] for r in result] == ["a", "b", "c"]
+    assert [r["source_text"] for r in result] == ["A", "B", "C"]
+
+
+def test_extract_translated_records_non_dict_item_ignored():
+    helper = RecordTranslationHelper()
+    original = [{"record_id": "r1", "source_text": "你好"}]
+    translated_payload = {"records": ["not a dict", {"record_id": "r1", "source_text": "Hello"}]}
+    result = helper.extract_translated_records(original, translated_payload)
+    assert result[0]["source_text"] == "Hello"
+
+
+def test_extract_translated_records_empty_payload():
+    helper = RecordTranslationHelper()
+    original = [{"record_id": "r1", "source_text": "你好"}]
+    result = helper.extract_translated_records(original, {"records": []})
+    assert result[0]["source_text"] == "你好"  # unchanged
+
+
+# ======================================================================
+# write_payload_to_file / read_translated_payload
+# ======================================================================
+
+def test_write_and_read_payload(tmp_path):
+    helper = RecordTranslationHelper()
+    records = [{"record_id": "r1", "source_text": "你好"}]
+    out_path = helper.write_payload_to_file(records, tmp_path / "test.json")
+
+    assert out_path.exists()
+    loaded = json.loads(out_path.read_text(encoding="utf-8"))
+    assert loaded == {"records": [{"record_id": "r1", "source_text": "你好"}]}
+
+
+def test_read_translated_payload(tmp_path):
+    helper = RecordTranslationHelper()
+    data = {"records": [{"record_id": "r1", "source_text": "Hello"}]}
+    path = tmp_path / "translated.json"
+    path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+    loaded = helper.read_translated_payload(path)
+    assert loaded == data


### PR DESCRIPTION
## Summary

- Add RecordTranslationHelper utility class for batch record translation with ID tracking
- Add Client.translate_records() and 	ranslate_records_async() convenience methods to SDK
- Add JSONPath parsing error signal in JsonTranslator for better debugging
- Add comprehensive tests (15 total: 13 for record helper, 2 for JSON translator)
- Update README with record translation documentation

## Motivation

This enables users who need batch text translation with ID tracking (CMS exports, database dumps, CAD annotations, subtitle files, etc.) to use DocuTranslate as a pip package without writing custom adapter code.

## Changes

| File | Type | Description |
|------|------|-------------|
| docutranslate/workflow/record_helper.py | New | RecordTranslationHelper + RecordFieldMapping classes |
| docutranslate/sdk.py | Modified | translate_records() + translate_records_async() methods |
| docutranslate/translator/ai_translator/json_translator.py | Modified | JSONPath error signal improvement |
| 	ests/test_workflow/test_record_helper.py | New | 13 tests for record helper |
| 	ests/test_translator/test_json_translator.py | New | 2 tests for JSON translator |
| README.md | Modified | Record translation documentation |
| .gitignore | Modified | Allow new test files |

## Testing

All 15 tests pass.