### PR TITLE
修复了修改并发任务数不生效的BUG

### DIFF
--- a/frontend/src/composables/useTasks.js
+++ b/frontend/src/composables/useTasks.js
@@ -34,13 +34,12 @@ const formatError = (data) => {
 };
 
 export function useTasks(settings, glossary, i18n) {
-    const { form, workflowParams, default_workflows, saveSetting, saveAllSettings, updatePlatformParams, STORAGE, errors, webSkipValidation } = settings;
+    const { form, workflowParams, default_workflows, queue_concurrent, saveSetting, saveAllSettings, updatePlatformParams, STORAGE, errors, webSkipValidation } = settings;
     const { glossaryData } = glossary;
     const { t } = i18n;
 
     const tasks = ref([]);
     const runningCount = ref(0);
-    const queue_concurrent = ref(3);
 
     // Pending queue for batch processing
     const pendingQueue = [];


### PR DESCRIPTION
refactor(useTasks): 将并发队列配置从本地硬编码改为从settings读取, 移除本地硬编码的并发队列默认值，统一从传入的settings中获取配置参数